### PR TITLE
feat(integrations): manage string body response that is not a json, liv-12186

### DIFF
--- a/lib/pipedrive/base.rb
+++ b/lib/pipedrive/base.rb
@@ -73,7 +73,6 @@ module Pipedrive
       failed_res.merge!(success: false, not_authorized: false, failed: false)
       failed_res.merge!(res.headers)
 
-      # failed_res = res.body.merge(success: false, not_authorized: false, failed: false).merge(res.headers)
       case res.status
       when 401
         failed_res[:not_authorized] = true

--- a/spec/lib/pipedrive/base_spec.rb
+++ b/spec/lib/pipedrive/base_spec.rb
@@ -41,6 +41,27 @@ RSpec.describe ::Pipedrive::Base do
       )
     end
 
+    context "when the body is a string" do
+      let(:res) do
+        instance_double(
+          Faraday::Response,
+          body: "Too many requests",
+          status: 429,
+          headers: ::Hashie::Mash.new({foo: :bar})
+        )
+      end
+
+      it "returns an error hash" do
+        expect(subject).to eq(::Hashie::Mash.new({
+          body: "Too many requests",
+          failed: false,
+          not_authorized: false,
+          success: false,
+          foo: :bar,
+        }))
+      end
+    end
+
     context "status is 401" do
       let(:status) { 401 }
 


### PR DESCRIPTION
See https://linear.app/livestorm/issue/LIV-12186/pipedrive-fix-nomethoderror-in-pipedrive-gem-for-non-json-responses